### PR TITLE
Escape Period Characters in Parser Regexes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.0)
+    librariesio-url-parser (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/bitbucket_url_parser.rb
+++ b/lib/bitbucket_url_parser.rb
@@ -15,6 +15,6 @@ class BitbucketURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(bitbucket.com|bitbucket.org)+?(:|\/)?/i, '')
+    url.gsub!(/(bitbucket\.com|bitbucket\.org)+?(:|\/)?/i, '')
   end
 end

--- a/lib/github_url_parser.rb
+++ b/lib/github_url_parser.rb
@@ -15,6 +15,6 @@ class GithubURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(github\.io|github\.com|github\.org|raw.githubusercontent.com)+?(:|\/)?/i, '')
+    url.gsub!(/(github\.io|github\.com|github\.org|raw\.githubusercontent\.com)+?(:|\/)?/i, '')
   end
 end

--- a/lib/github_url_parser.rb
+++ b/lib/github_url_parser.rb
@@ -15,6 +15,6 @@ class GithubURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(github.io|github.com|github.org|raw.githubusercontent.com)+?(:|\/)?/i, '')
+    url.gsub!(/(github\.io|github\.com|github\.org|raw.githubusercontent.com)+?(:|\/)?/i, '')
   end
 end

--- a/lib/gitlab_url_parser.rb
+++ b/lib/gitlab_url_parser.rb
@@ -15,6 +15,6 @@ class GitlabURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(gitlab.com)+?(:|\/)?/i, '')
+    url.gsub!(/(gitlab\.com)+?(:|\/)?/i, '')
   end
 end

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -6,5 +6,5 @@ require_relative "github_url_parser"
 require_relative "gitlab_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -58,6 +58,7 @@ describe GithubURLParser do
       ['github.com/1995hnagamin/hubot-achievements', '1995hnagamin/hubot-achievements'],
       ['git//github.com/divyavanmahajan/jsforce_downloader.git', 'divyavanmahajan/jsforce_downloader'],
       ['scm:git:https://michaelkrog@github.com/michaelkrog/filter4j.git', 'michaelkrog/filter4j'],
+      ['github.com/github/combobox-nav', 'github/combobox-nav']
     ].each do |row|
       url, full_name = row
       result = GithubURLParser.parse(url)


### PR DESCRIPTION
The regexes currently only have a `.` which will match any character. Which was why `github/com` was getting picked up and removed from names. 