### PR TITLE
Only Replace First Occurence of Domain in URLs

### DIFF
--- a/lib/bitbucket_url_parser.rb
+++ b/lib/bitbucket_url_parser.rb
@@ -15,6 +15,9 @@ class BitbucketURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(bitbucket\.com|bitbucket\.org)+?(:|\/)?/i, '')
+    # find the matches for any github domain characters in the url string
+    # and replace only the first match incase we find a repo with something like github.com as the name
+    matches = /(bitbucket\.com|bitbucket\.org)+?(:|\/)?/i.match(url)
+    url.gsub!(matches[0], '') if matches
   end
 end

--- a/lib/bitbucket_url_parser.rb
+++ b/lib/bitbucket_url_parser.rb
@@ -17,7 +17,6 @@ class BitbucketURLParser < URLParser
   def remove_domain
     # find the matches for any github domain characters in the url string
     # and replace only the first match incase we find a repo with something like github.com as the name
-    matches = /(bitbucket\.com|bitbucket\.org)+?(:|\/)?/i.match(url)
-    url.gsub!(matches[0], '') if matches
+    url.sub!(/(bitbucket\.com|bitbucket\.org)+?(:|\/)?/i, '')
   end
 end

--- a/lib/github_url_parser.rb
+++ b/lib/github_url_parser.rb
@@ -17,7 +17,6 @@ class GithubURLParser < URLParser
   def remove_domain
     # find the matches for any github domain characters in the url string
     # and replace only the first match incase we find a repo with something like github.com as the name
-    matches = /(github\.io|github\.com|github\.org|raw\.githubusercontent\.com)+?(:|\/)?/i.match(url)
-    url.gsub!(matches[0], '') if matches
+    url.sub!(/(github\.io|github\.com|github\.org|raw\.githubusercontent\.com)+?(:|\/)?/i, '')
   end
 end

--- a/lib/github_url_parser.rb
+++ b/lib/github_url_parser.rb
@@ -15,6 +15,9 @@ class GithubURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(github\.io|github\.com|github\.org|raw\.githubusercontent\.com)+?(:|\/)?/i, '')
+    # find the matches for any github domain characters in the url string
+    # and replace only the first match incase we find a repo with something like github.com as the name
+    matches = /(github\.io|github\.com|github\.org|raw\.githubusercontent\.com)+?(:|\/)?/i.match(url)
+    url.gsub!(matches[0], '') if matches
   end
 end

--- a/lib/gitlab_url_parser.rb
+++ b/lib/gitlab_url_parser.rb
@@ -15,6 +15,9 @@ class GitlabURLParser < URLParser
   end
 
   def remove_domain
-    url.gsub!(/(gitlab\.com)+?(:|\/)?/i, '')
+    # find the matches for any github domain characters in the url string
+    # and replace only the first match incase we find a repo with something like github.com as the name
+    matches = /(gitlab\.com)+?(:|\/)?/i.match(url)
+    url.gsub!(matches[0], '') if matches
   end
 end

--- a/lib/gitlab_url_parser.rb
+++ b/lib/gitlab_url_parser.rb
@@ -17,7 +17,6 @@ class GitlabURLParser < URLParser
   def remove_domain
     # find the matches for any github domain characters in the url string
     # and replace only the first match incase we find a repo with something like github.com as the name
-    matches = /(gitlab\.com)+?(:|\/)?/i.match(url)
-    url.gsub!(matches[0], '') if matches
+    url.sub!(/(gitlab\.com)+?(:|\/)?/i, '')
   end
 end

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -58,7 +58,9 @@ describe GithubURLParser do
       ['github.com/1995hnagamin/hubot-achievements', '1995hnagamin/hubot-achievements'],
       ['git//github.com/divyavanmahajan/jsforce_downloader.git', 'divyavanmahajan/jsforce_downloader'],
       ['scm:git:https://michaelkrog@github.com/michaelkrog/filter4j.git', 'michaelkrog/filter4j'],
-      ['github.com/github/combobox-nav', 'github/combobox-nav']
+      ['github.com/github/combobox-nav', 'github/combobox-nav'],
+      ['github.com/hhao785/github.com', 'hhao785/github.com'],
+      ['github.com/contrived_example/githubcom', 'contrived_example/githubcom']
     ].each do |row|
       url, full_name = row
       result = GithubURLParser.parse(url)


### PR DESCRIPTION
Replaces only the first occurrence of a domain in the repository url in case we run into a repository called `github.com`.