### PR TITLE
Add Support for Apache Gitbox Website

### DIFF
--- a/lib/apache_gitbox_url_parser.rb
+++ b/lib/apache_gitbox_url_parser.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+class ApacheGitboxUrlParser < URLParser
+  private
+
+  def full_domain
+    'https://gitbox.apache.org/repos/asf'
+  end
+
+  def tlds
+    %w(org)
+  end
+
+  def domain
+    'gitbox.apache'
+  end
+
+  def remove_querystring
+    url
+  end
+
+  def remove_equals_sign
+    # we need to preserve the p=<some_name> query parameter
+    splits = url.split('=')
+    p_index = splits.index{|s| s.end_with?("?p") || s.end_with?("&p")}
+    if p_index
+      new_url = splits[0..p_index+1].join("=") if p_index
+      # remove separator characters present at the end of this string
+      # before the next parameter in the query parameter list
+      # ";"
+      new_url.gsub!(/[;,&].*/, '')
+
+      self.url = new_url
+    end
+  end
+
+  def domain_regex
+    # match only the viewvc endpoint at the domain
+    "#{domain.split("/").first}\.(#{tlds.join('|')})\/repos"
+  end
+
+  def remove_domain
+    # find the matches for any github domain characters in the url string
+    # and replace only the first match incase we find a repo with something like github.com as the name
+    url.sub!(/(gitbox\.apache\.org\/(repos\/asf))+?(:|\/)?/i, '')
+  end
+
+  def remove_extra_segments
+    if url.is_a?(String) && url.start_with?("?p=")
+      self.url = url.split("=").last
+    end
+  end
+
+  def format_url
+    url.is_a?(String) ? url : nil
+  end
+end

--- a/lib/apache_gitbox_url_parser.rb
+++ b/lib/apache_gitbox_url_parser.rb
@@ -15,6 +15,8 @@ class ApacheGitboxUrlParser < URLParser
   end
 
   def remove_querystring
+    # it is common for the name to be passed in as a query parameter so we need to keep them in
+    # the url string for now and process them in later steps to pull the name out of the parameter
     url
   end
 
@@ -34,23 +36,24 @@ class ApacheGitboxUrlParser < URLParser
   end
 
   def domain_regex
-    # match only the viewvc endpoint at the domain
-    "#{domain.split("/").first}\.(#{tlds.join('|')})\/repos"
+    # match only the repos/asf endpoint at the domain
+    "#{domain.split("/").first}\.(#{tlds.join('|')})\/repos/asf"
   end
 
   def remove_domain
-    # find the matches for any github domain characters in the url string
-    # and replace only the first match incase we find a repo with something like github.com as the name
     url.sub!(/(gitbox\.apache\.org\/(repos\/asf))+?(:|\/)?/i, '')
   end
 
   def remove_extra_segments
+    # by the time the URL gets here it should have been mostly pared down to the correct name
+    # however if the name was passed as a query parameter the ?p= is still at the front of the name
     if url.is_a?(String) && url.start_with?("?p=")
       self.url = url.split("=").last
     end
   end
 
   def format_url
+    # ignore something if it comes in at as an Array at this point
     url.is_a?(String) ? url : nil
   end
 end

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -8,5 +8,5 @@ require_relative "apache_svn_url_parser"
 require_relative "apache_gitbox_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -5,6 +5,7 @@ require_relative "bitbucket_url_parser"
 require_relative "github_url_parser"
 require_relative "gitlab_url_parser"
 require_relative "apache_svn_url_parser"
+require_relative "apache_gitbox_url_parser"
 
 module LibrariesioURLParser
   VERSION = "1.0.2"

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -31,7 +31,8 @@ class URLParser
     GithubURLParser.parse_to_full_url(url) ||
     GitlabURLParser.parse_to_full_url(url) ||
     BitbucketURLParser.parse_to_full_url(url) ||
-    ApacheSvnUrlParser.parse_to_full_url(url)
+    ApacheSvnUrlParser.parse_to_full_url(url) ||
+    ApacheGitboxUrlParser.parse_to_full_url(url)
   end
 
   def parse_to_full_url

--- a/spec/apache_gitbox_url_parser_spec.rb
+++ b/spec/apache_gitbox_url_parser_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe ApacheGitboxUrlParser do
+
+  describe "#parse" do
+    it 'parses apache svn urls' do
+      [
+        %w[https://gitbox.apache.org/repos/asf?p=camel-quarkus.git;a=summary camel-quarkus],
+        %w[https://gitbox.apache.org/repos/asf/metamodel.git metamodel]
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse(url)
+        expect(result).to eq(full_name)
+      end
+    end
+
+    it "doesn't parse the Apache repos URL" do
+      url = "scm:svn:https://svn.apache.org/repos/asf/stanbol/tags/apache-stanbol-1.0.0/release-1.0.0-branch/stanbol.apache.org"
+      expect(described_class.parse(url)).to be_nil
+    end
+  end
+
+  describe "#parse_to_full_url" do
+    it 'parses apache svn urls' do
+      [
+        %w[https://gitbox.apache.org/repos/asf?p=camel-quarkus.git;a=summary https://gitbox.apache.org/repos/asf/camel-quarkus],
+        %w[https://gitbox.apache.org/repos/asf/metamodel.git https://gitbox.apache.org/repos/asf/metamodel]
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse_to_full_url(url)
+        expect(result).to eq(full_name)
+      end
+    end
+  end
+end

--- a/spec/apache_gitbox_url_parser_spec.rb
+++ b/spec/apache_gitbox_url_parser_spec.rb
@@ -6,17 +6,14 @@ describe ApacheGitboxUrlParser do
     it 'parses apache svn urls' do
       [
         %w[https://gitbox.apache.org/repos/asf?p=camel-quarkus.git;a=summary camel-quarkus],
-        %w[https://gitbox.apache.org/repos/asf/metamodel.git metamodel]
+        %w[https://gitbox.apache.org/repos/asf/metamodel.git metamodel],
+        %w[https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-testing-resourceresolver-mock.git sling-org-apache-sling-testing-resourceresolver-mock],
+        %w[https://gitbox.apache.org/repos/asf?p=lucene-solr.git;f=lucene lucene-solr]
       ].each do |row|
         url, full_name = row
         result = described_class.parse(url)
         expect(result).to eq(full_name)
       end
-    end
-
-    it "doesn't parse the Apache repos URL" do
-      url = "scm:svn:https://svn.apache.org/repos/asf/stanbol/tags/apache-stanbol-1.0.0/release-1.0.0-branch/stanbol.apache.org"
-      expect(described_class.parse(url)).to be_nil
     end
   end
 


### PR DESCRIPTION
This adds support for parsing URLs for the Apache Software Foundation git mirror https://gitbox.apache.org/repos/asf

