### PR TITLE
URLParser: memoize self.descendents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.3)
+    librariesio-url-parser (1.0.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -13,5 +13,5 @@ require_relative "android_googlesource_url_parser"
 require_relative "sourceforge_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -162,13 +162,20 @@ class URLParser
     url.gsub!(/\s/, '')
   end
 
+  # This computation is memoized because it is expensive. This prevents use cases which require using
+  # .try_all in a tight loop. However, if this class is required directly (without requiring any subparsers),
+  # this method will memoize an empty array. It is recommended to simply require librariesio-url-parser.rb directly.
+  # This is the default behavior when installing this gem.
   private_class_method def self.descendants
-    descendants = []
-    ObjectSpace.each_object(singleton_class) do |k|
-      next if k.singleton_class?
+    @descendants ||=
+      begin
+        descendants = []
+        ObjectSpace.each_object(singleton_class) do |k|
+          next if k.singleton_class?
 
-      descendants.unshift k unless k == self
-    end
-    descendants
+          descendants.unshift k unless k == self
+        end
+        descendants
+      end
   end
 end


### PR DESCRIPTION
Here's a performance comparison using RubyProf:

## Before

### Profiled Snippet

```ruby
1000.times { URLParser.try_all("http://github.com/foo/bar") }
```

### Relevant output

```
Total Time: 35.19508910179138

  %total   %self      total       self       wait      child            calls     name
--------------------------------------------------------------------------------
  99.54%  99.52%     35.033     35.026      0.000      0.007             1000     <Module::ObjectSpace>#each_object
```

Meaning that 99.52% of the 35 seconds it took to parse that url 1000 times was spent on `ObjectSpace.each_object` in `.descendents`

## After

### Profiled Snippet

```ruby
1_100_000.times { URLParser.try_all("github.com/foo/bar") }
```

### Relevant output

```
Total Time: 91.80359482765198

  %total   %self      total       self       wait      child            calls     name
--------------------------------------------------------------------------------
                      0.000      0.000      0.000      0.000            11/11     <Module::ObjectSpace>#each_object
   0.01%   0.01%      0.000      0.000      0.000      0.000               11     Module#singleton_class?
--------------------------------------------------------------------------------
                      0.000      0.000      0.000      0.000            10/10     <Module::ObjectSpace>#each_object
   0.00%   0.00%      0.000      0.000      0.000      0.000               10     Array#unshift
```

Meaning that this now takes basically no time when parsing 1.1M times. The 1.5 minutes it takes to parse that many records is now spread out over the various regex/array/string manipulation methods. I've uploaded the full profile [here](https://gist.github.com/mpace965/f2fc23d7909c80525b0da3c7c32e3ddc) if you're curious.