### PR TITLE
UrlParser: keep state consistent in clean_url and format_url when url does not include the domain

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.4)
+    librariesio-url-parser (1.0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -13,5 +13,5 @@ require_relative "android_googlesource_url_parser"
 require_relative "sourceforge_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -65,7 +65,12 @@ class URLParser
     remove_auth_user
     remove_equals_sign
     remove_scheme
-    return nil unless includes_domain?
+
+    unless includes_domain?
+      self.url = nil
+      return nil
+    end
+
     remove_subdomain
     remove_domain
     remove_git_extension
@@ -74,6 +79,7 @@ class URLParser
   end
 
   def format_url
+    return nil if url.nil?
     return nil unless url.length == 2
 
     url.join('/')

--- a/spec/sourceforge_url_parser_spec.rb
+++ b/spec/sourceforge_url_parser_spec.rb
@@ -27,4 +27,8 @@ describe SourceforgeUrlParser do
       end
     end
   end
+
+  it 'does not parse sourceforge.jp urls' do
+    expect(described_class.parse_to_full_url("http://svn.sourceforge.jp/svnroot/foo/")).to be_nil
+  end
 end


### PR DESCRIPTION
In `URLParser.try_all`, when `clean_url` returns early because `includes_domain?` returns false, we return `nil`, but don't update `self.url` accordingly. This erroneously produces a result in `format_url`, when parsing should not really continue.