### PR TITLE
UrlParser: remove git extension after removing extra segments

### DIFF
--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -168,13 +168,7 @@ class URLParser
   end
 
   def remove_git_extension
-    operand = if url.is_a?(Array)
-                url
-              else
-                [url]
-              end
-
-    operand.last&.gsub!(/(\.git|\/)$/i, '')
+    Array(url).last&.gsub!(/(\.git|\/)$/i, '')
   end
 
   def remove_git_scheme

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -96,9 +96,9 @@ class URLParser
 
     remove_subdomain
     remove_domain
-    remove_git_extension
     remove_git_scheme
     remove_extra_segments
+    remove_git_extension
   end
 
   def format_url
@@ -168,7 +168,13 @@ class URLParser
   end
 
   def remove_git_extension
-    url.gsub!(/(\.git|\/)$/i, '')
+    operand = if url.is_a?(Array)
+                url
+              else
+                [url]
+              end
+
+    operand.last&.gsub!(/(\.git|\/)$/i, '')
   end
 
   def remove_git_scheme

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -60,7 +60,8 @@ describe GithubURLParser do
       ['scm:git:https://michaelkrog@github.com/michaelkrog/filter4j.git', 'michaelkrog/filter4j'],
       ['github.com/github/combobox-nav', 'github/combobox-nav'],
       ['github.com/hhao785/github.com', 'hhao785/github.com'],
-      ['github.com/contrived_example/githubcom', 'contrived_example/githubcom']
+      ['github.com/contrived_example/githubcom', 'contrived_example/githubcom'],
+      ['scm:git:ssh://github.com/an-organization/a-repository.git/a-repository-subdirectory', 'an-organization/a-repository']
     ].each do |row|
       url, full_name = row
       result = GithubURLParser.parse(url)


### PR DESCRIPTION
Fixes a bug in url parsing where parsing a url like `scm:git:ssh://github.com/an-organization/a-repository.git/a-repository-subdirectory` yields the result `an-organization/a-repository.git` instead of `an-organization/a-repository`.