### PR TITLE
Remove Quotes from URL Strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# rubymine generated files
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.7)
+    librariesio-url-parser (1.0.8)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -13,5 +13,5 @@ require_relative "android_googlesource_url_parser"
 require_relative "sourceforge_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.7"
+  VERSION = "1.0.8"
 end

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -82,6 +82,7 @@ class URLParser
 
   def clean_url
     remove_whitespace
+    remove_quotes
     remove_brackets
     remove_anchors
     remove_querystring
@@ -189,5 +190,9 @@ class URLParser
 
   def remove_whitespace
     url.gsub!(/\s/, '')
+  end
+
+  def remove_quotes
+    url.gsub!(/["']/, '')
   end
 end

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -61,7 +61,8 @@ describe GithubURLParser do
       ['github.com/github/combobox-nav', 'github/combobox-nav'],
       ['github.com/hhao785/github.com', 'hhao785/github.com'],
       ['github.com/contrived_example/githubcom', 'contrived_example/githubcom'],
-      ['scm:git:ssh://github.com/an-organization/a-repository.git/a-repository-subdirectory', 'an-organization/a-repository']
+      ['scm:git:ssh://github.com/an-organization/a-repository.git/a-repository-subdirectory', 'an-organization/a-repository'],
+      ['https://github.com/"/maxcdn/shml/', 'maxcdn/shml']
     ].each do |row|
       url, full_name = row
       result = GithubURLParser.parse(url)
@@ -108,6 +109,19 @@ describe GithubURLParser do
       result = GithubURLParser.parse(url)
       expect(result).to eq(nil)
     end
+  end
+
+  it 'handles quotes' do
+    [
+      ['https://github.com/"/maxcdn/shml/', 'maxcdn/shml'],
+      ['https://github.com/"sunilrumbalama/docxtopdf"', 'sunilrumbalama/docxtopdf'],
+      ['https://github.com/"insertkoinio/koin.git"', 'insertkoinio/koin'],
+      ["https://github.com/'insertkoinio/koin.git", "insertkoinio/koin"]
+    ].each do |row|
+        url, full_name = row
+        result = GithubURLParser.parse(url)
+        expect(result).to eq(full_name)
+      end
   end
 
   describe '#case_sensitive?' do


### PR DESCRIPTION
Removes `"` and `'` characters from the URL repository string before parsing.