### PR TITLE
Fix the User URL Parsing Method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.8)
+    librariesio-url-parser (1.0.9)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -13,5 +13,5 @@ require_relative "android_googlesource_url_parser"
 require_relative "sourceforge_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end

--- a/spec/bitbucket_url_parser_spec.rb
+++ b/spec/bitbucket_url_parser_spec.rb
@@ -111,4 +111,20 @@ describe BitbucketURLParser do
       expect(described_class.case_sensitive?).to be(false)
     end
   end
+
+  describe "#parse_to_full_user_url" do
+    it "parses User URLs" do
+      [
+        ['https://bitbucket.org/myuser', 'https://bitbucket.org/myuser'],
+        ['https://bitbucket.org/"/myuser', 'https://bitbucket.org/myuser'],
+        ['https://bitbucket.org/myuser#anchor', 'https://bitbucket.org/myuser'],
+        ['https://bitbucket.org/myuser?foo=bar&wut=wah', 'https://bitbucket.org/myuser'],
+        ["(https://bitbucket.org/myuser)", "https://bitbucket.org/myuser"]
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse_to_full_user_url(url)
+        expect(result).to eq(full_name)
+      end
+    end
+  end
 end

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -129,4 +129,20 @@ describe GithubURLParser do
       expect(described_class.case_sensitive?).to be(false)
     end
   end
+
+  describe "#parse_to_full_user_url" do
+    it "parses User URLs" do
+      [
+        ['https://github.com/myuser', 'https://github.com/myuser'],
+        ['https://github.com/"/myuser', 'https://github.com/myuser'],
+        ['https://github.com/myuser#anchor', 'https://github.com/myuser'],
+        ['https://github.com/myuser?foo=bar&wut=wah', 'https://github.com/myuser'],
+        ["(https://github.com/myuser)", "https://github.com/myuser"]
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse_to_full_user_url(url)
+        expect(result).to eq(full_name)
+      end
+    end
+  end
 end

--- a/spec/github_url_parser_spec.rb
+++ b/spec/github_url_parser_spec.rb
@@ -144,5 +144,16 @@ describe GithubURLParser do
         expect(result).to eq(full_name)
       end
     end
+
+    it "handles incorrect URLs" do
+      [
+        ['https://github.com/some/extra/paths', nil],
+        ['https://github.com/', nil],
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse_to_full_user_url(url)
+        expect(result).to eq(full_name)
+      end
+    end
   end
 end

--- a/spec/gitlab_url_parser_spec.rb
+++ b/spec/gitlab_url_parser_spec.rb
@@ -105,4 +105,20 @@ describe GitlabURLParser do
       expect(described_class.case_sensitive?).to be(false)
     end
   end
+
+  describe "#parse_to_full_user_url" do
+    it "parses User URLs" do
+      [
+        ['https://gitlab.com/myuser', 'https://gitlab.com/myuser'],
+        ['https://gitlab.com/"/myuser', 'https://gitlab.com/myuser'],
+        ['https://gitlab.com/myuser#anchor', 'https://gitlab.com/myuser'],
+        ['https://gitlab.com/myuser?foo=bar&wut=wah', 'https://gitlab.com/myuser'],
+        ["(https://gitlab.com/myuser)", "https://gitlab.com/myuser"]
+      ].each do |row|
+        url, full_name = row
+        result = described_class.parse_to_full_user_url(url)
+        expect(result).to eq(full_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixed how the URL was being accessed for the `parse_to_full_user_url` method to fix it always returning `nil` and added some comments around a few of the methods to describe what the expected return type is. There is a mix of methods modifying the URL string in place vs callers expecting a returned result. It's probably worth a clean up in here to be consistent either way, but this PR should at least fix the method that was breaking Libraries.io.