### PR TITLE
URLParser: don't error on splitting an empty string

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    librariesio-url-parser (1.0.10)
+    librariesio-url-parser (1.0.11)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/librariesio-url-parser.rb
+++ b/lib/librariesio-url-parser.rb
@@ -13,5 +13,5 @@ require_relative "android_googlesource_url_parser"
 require_relative "sourceforge_url_parser"
 
 module LibrariesioURLParser
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/lib/url_parser.rb
+++ b/lib/url_parser.rb
@@ -175,7 +175,7 @@ class URLParser
   end
 
   def remove_auth_user
-    self.url = url.split('@')[-1]
+    self.url = last_field(url, '@')
   end
 
   def remove_domain
@@ -187,7 +187,7 @@ class URLParser
   end
 
   def remove_equals_sign
-    self.url = url.split('=')[-1]
+    self.url = last_field(url, '=')
   end
 
   def remove_extra_segments
@@ -220,5 +220,16 @@ class URLParser
 
   def remove_quotes
     url.gsub!(/["']/, '')
+  end
+
+  def last_field(s, pattern)
+    # "".split(pattern) = [], not [""], but we want to return ""
+    # https://chriszetter.com/blog/2017/10/29/splitting-strings/
+    fields = s.split(pattern)
+    if fields.empty?
+      +""
+    else
+      fields[-1]
+    end
   end
 end

--- a/spec/url_parser_spec.rb
+++ b/spec/url_parser_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe URLParser do
+  class MinimalURLParser < URLParser
+    def domain
+      "example"
+    end
+
+    def tlds
+      ["com"]
+    end
+
+    def remove_domain
+      url.sub!(/(example\.com)+?(:|\/)?/i, '')
+    end
+  end
+
+  it "cleans urls" do
+    # the specific URLParser subclasses test a bunch more examples, but if you're working on a bug
+    # that's generic to the base class, feel free to add stuff here.
+    examples = [
+      ["https://example.com/foo/bar", ["foo", "bar"]],
+      ["[?] Project git repository (git://example.com/a.stadnik/dev-assets.git)", nil]
+    ]
+    results = examples.map(&:first).map do |url|
+      parser = MinimalURLParser.new(url)
+      parser.send(:clean_url!)
+      parser.send(:url)
+    end
+
+    expected_results = examples.map { |ex| ex[1] }
+
+    expect(results).to eq(expected_results)
+  end
+end


### PR DESCRIPTION
"".split(pattern)=[], and [][-1]=nil, and nil was not
expected.
